### PR TITLE
Adds quick and dirty rake task to delete stories after 1 month.

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,4 +1,5 @@
 class Story < ActiveRecord::Base
+  DELETION_INTERVAL = 1.month
   belongs_to :user
   belongs_to :merged_into_story,
     :class_name => "Story",
@@ -19,6 +20,7 @@ class Story < ActiveRecord::Base
     :source => :user
 
   scope :unmerged, -> { where(:merged_story_id => nil) }
+  scope :ready_for_deletion, -> { where('created_at < ?', DELETION_INTERVAL.ago) }
 
   validates_length_of :title, :in => 3..150
   validates_length_of :description, :maximum => (64 * 1024)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -8,16 +8,24 @@ class Story < ActiveRecord::Base
     :class_name => "Story",
     :foreign_key => "merged_story_id"
   has_many :taggings,
-    :autosave => true
-  has_many :suggested_taggings
-  has_many :suggested_titles
+           :autosave => true,
+           :dependent => :delete_all
+  has_many :suggested_taggings,
+           :dependent => :delete_all
+  has_many :suggested_titles,
+           :dependent => :delete_all
   has_many :comments,
-    :inverse_of => :story
+           :inverse_of => :story,
+           :dependent => :delete_all
   has_many :tags, :through => :taggings
-  has_many :votes, -> { where(:comment_id => nil) }
+  has_many :votes,
+           -> { where(:comment_id => nil) },
+           :dependent => :delete_all
   has_many :voters, -> { where('votes.comment_id' => nil) },
     :through => :votes,
     :source => :user
+
+
 
   scope :unmerged, -> { where(:merged_story_id => nil) }
   scope :ready_for_deletion, -> { where('created_at < ?', DELETION_INTERVAL.ago) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,13 +91,6 @@ class User < ActiveRecord::Base
   # minimum karma required to be able to submit new stories
   MIN_KARMA_TO_SUBMIT_STORIES = -4
 
-  def self.recalculate_all_karmas!
-    User.all.each do |u|
-      u.karma = u.stories.map(&:score).sum + u.comments.map(&:score).sum
-      u.save!
-    end
-  end
-
   def self.username_regex_s
     "/^" + VALID_USERNAME.to_s.gsub(/(\?-mix:|\(|\))/, "") + "$/"
   end

--- a/lib/tasks/delete_old_stories.rake
+++ b/lib/tasks/delete_old_stories.rake
@@ -1,0 +1,5 @@
+task :delete_old_stories => :environment do
+  Story.ready_for_deletion.each do |story|
+    story.delete
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -6,4 +6,14 @@ describe Comment do
 
     c.short_id.should match(/^\A[a-zA-Z0-9]{1,10}\z/)
   end
+
+  describe "destroy" do
+    it "destroys its votes" do
+      c = Comment.make!()
+
+      expect {
+        c.destroy
+      }.to change(Vote, :count).by(-1)
+    end
+  end
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -16,6 +16,24 @@ describe Story do
   end
 
   describe "destroy" do
+    it "preserves users karma" do
+      submitter = User.make!
+      upvoter = User.make!
+      commenter = User.make!
+      comment_upvoter = User.make!
+      s = Story.make!(:user_id => submitter.id)
+      Vote.vote_thusly_on_story_or_comment_for_user_because(1, s.id, nil, upvoter.id, nil, true)
+      comment = Comment.make!(:story_id => s.id, :user_id => commenter.id)
+      Vote.vote_thusly_on_story_or_comment_for_user_because(1, s.id, comment.id, comment_upvoter.id, nil, true)
+      expect(submitter.reload.karma).to eq 1
+      expect(commenter.reload.karma).to eq 1
+
+      s.destroy
+
+      expect(submitter.reload.karma).to eq 1
+      expect(commenter.reload.karma).to eq 1
+    end
+
     it "deletes a story's taggings" do
       s = Story.make!(:tags_a => ["tag1"])
 

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,6 +1,20 @@
 require "spec_helper"
 
 describe Story do
+
+  describe "self.ready_for_deletion" do
+    it "includes stories older than 1 month" do
+      s = Story.make!(:created_at => 5.months.ago)
+      expect( Story.ready_for_deletion).to include(s)
+    end
+
+    it "does not include stories less than 1 month old" do
+      s = Story.make!(:created_at => 3.weeks.ago)
+
+      expect(Story.ready_for_deletion).to_not include(s)
+    end
+  end
+
   it "should get a short id" do
     s = Story.make!(:title => "hello", :url => "http://example.com/")
 

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -15,6 +15,45 @@ describe Story do
     end
   end
 
+  describe "destroy" do
+    it "deletes a story's taggings" do
+      s = Story.make!(:tags_a => ["tag1"])
+
+      expect {
+        s.destroy
+      }.to change(Tagging, :count).by(-1)
+    end
+
+    it "deletes a story's comments" do
+      s = Story.make!(:comments => [Comment.make!])
+
+      expect {
+        s.destroy
+      }.to change(Comment, :count).by(-1)
+    end
+
+    it "deletes a story's votes" do
+      s = Story.make!
+
+      expect {
+        s.destroy
+      }.to change(Vote, :count).by(-1)
+    end
+
+    it "deletes a story's suggestions" do
+      s = Story.make!(
+        :suggested_taggings => [SuggestedTagging.make!],
+        :suggested_titles => [SuggestedTitle.make!]
+      )
+
+      expect {
+        expect {
+          s.destroy
+        }.to change(SuggestedTagging, :count).by(-1)
+      }.to change(SuggestedTitle, :count).by(-1)
+    end
+  end
+
   it "should get a short id" do
     s = Story.make!(:title => "hello", :url => "http://example.com/")
 

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -50,3 +50,15 @@ Vote.blueprint do
   user
   vote { 1 }
 end
+
+SuggestedTagging.blueprint do
+  tag
+  story
+  user
+end
+
+SuggestedTitle.blueprint do
+  story
+  user
+  title { "suggestion #{sn}"}
+end


### PR DESCRIPTION
There was talk about allowing the ability to stop a story from being deleted. Should be easy enough to implement that by updating the relevant scope.

This will require a change to the deployment to run another scheduled task.