### PR TITLE
Make it clear when a story will be deleted.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -101,6 +101,18 @@ span.na {
 	font-style: italic;
 }
 
+span.low-urgency {
+    color:gray;
+}
+
+span.medium-urgency {
+    color: #edac7b;
+}
+
+span.high-urgency {
+    color: #700;
+}
+
 div.shorten_first_p p:first-child {
 	margin-top: 0.5em;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,6 +69,28 @@ module ApplicationHelper
     pages
   end
 
+  def time_until_deletion_label(time)
+    end_time = time.seconds.from_now
+    ago = time_ago_in_words(end_time)
+    raw(content_tag(
+          :span,
+          "archival in #{ago}",
+          :title => end_time.strftime("%F %T %z"),
+          :class => urgency_class(time)
+        )
+    )
+  end
+
+  def urgency_class(time)
+    if time.seconds < 1.days
+      "high-urgency"
+    elsif time.seconds < 1.weeks
+      "medium-urgency"
+    else
+      "low-urgency"
+    end
+  end
+
   def time_ago_in_words_label(time, options = {})
     ago = ""
     secs = (Time.now - time).to_i

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,8 @@
 class Comment < ActiveRecord::Base
   belongs_to :user
   belongs_to :story,
-    :inverse_of => :comments
+             :inverse_of => :comments,
+             :touch => true
   has_many :votes,
     :dependent => :delete_all
   belongs_to :parent_comment,

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -28,7 +28,7 @@ class Story < ActiveRecord::Base
 
 
   scope :unmerged, -> { where(:merged_story_id => nil) }
-  scope :ready_for_deletion, -> { where('created_at < ?', DELETION_INTERVAL.ago) }
+  scope :ready_for_deletion, -> { where('updated_at < ?', DELETION_INTERVAL.ago) }
 
   validates_length_of :title, :in => 3..150
   validates_length_of :description, :maximum => (64 * 1024)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,5 +1,5 @@
 class Story < ActiveRecord::Base
-  DELETION_INTERVAL = 1.month
+  DELETION_INTERVAL = 4.weeks
   belongs_to :user
   belongs_to :merged_into_story,
     :class_name => "Story",
@@ -153,6 +153,11 @@ class Story < ActiveRecord::Base
 
   def self.votes_cast_type
     Story.connection.adapter_name.match(/mysql/i) ? "signed" : "integer"
+  end
+
+  def time_until_deletion(now = Time.now)
+    delete_at = updated_at + DELETION_INTERVAL
+    delete_at - now
   end
 
   def archive_url

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -118,6 +118,10 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
           story.html_class_for_user %>"><%= story.user.username %></a>
 
         <%= time_ago_in_words_label(story.created_at, :strip_about => true) %>
+        <% if story.time_until_deletion < 2.weeks.to_i %>
+            |
+            <%= time_until_deletion_label(story.time_until_deletion) %>
+        <% end %>
 
         <% if story.is_editable_by_user?(@user) %>
           |

--- a/db/migrate/20170526042742_add_stories_updated_at.rb
+++ b/db/migrate/20170526042742_add_stories_updated_at.rb
@@ -1,0 +1,5 @@
+class AddStoriesUpdatedAt < ActiveRecord::Migration
+  def change
+    add_column :stories, :updated_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,25 +11,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170522144135) do
+ActiveRecord::Schema.define(version: 20170526042742) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "comments", force: :cascade do |t|
-    t.datetime "created_at",                                                                    null: false
+    t.datetime "created_at",                                                              null: false
     t.datetime "updated_at"
-    t.string   "short_id",           limit: 10,                                 default: "",    null: false
-    t.integer  "story_id",           limit: 4,                                                  null: false
-    t.integer  "user_id",            limit: 4,                                                  null: false
-    t.integer  "parent_comment_id",  limit: 4
-    t.integer  "thread_id",          limit: 4
-    t.text     "comment",            limit: 16777215,                                           null: false
-    t.integer  "upvotes",            limit: 4,                                  default: 0,     null: false
-    t.integer  "downvotes",          limit: 4,                                  default: 0,     null: false
-    t.decimal  "confidence",                          precision: 20, scale: 19, default: 0.0,   null: false
-    t.text     "markeddown_comment", limit: 16777215
-    t.boolean  "is_deleted",                                                    default: false
-    t.boolean  "is_moderated",                                                  default: false
-    t.boolean  "is_from_email",                                                 default: false
-    t.integer  "hat_id",             limit: 4
+    t.string   "short_id",           limit: 10,                           default: "",    null: false
+    t.integer  "story_id",                                                                null: false
+    t.integer  "user_id",                                                                 null: false
+    t.integer  "parent_comment_id"
+    t.integer  "thread_id"
+    t.text     "comment",                                                                 null: false
+    t.integer  "upvotes",                                                 default: 0,     null: false
+    t.integer  "downvotes",                                               default: 0,     null: false
+    t.decimal  "confidence",                    precision: 20, scale: 19, default: 0.0,   null: false
+    t.text     "markeddown_comment"
+    t.boolean  "is_deleted",                                              default: false
+    t.boolean  "is_moderated",                                            default: false
+    t.boolean  "is_from_email",                                           default: false
+    t.integer  "hat_id"
   end
 
   add_index "comments", ["confidence"], name: "confidence_idx", using: :btree
@@ -41,46 +44,46 @@ ActiveRecord::Schema.define(version: 20170522144135) do
   create_table "hat_requests", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id",    limit: 4
+    t.integer  "user_id"
     t.string   "hat",        limit: 255
     t.string   "link",       limit: 255
-    t.text     "comment",    limit: 65535
+    t.text     "comment"
   end
 
   create_table "hats", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id",            limit: 4
-    t.integer  "granted_by_user_id", limit: 4
+    t.integer  "user_id"
+    t.integer  "granted_by_user_id"
     t.string   "hat",                limit: 255
     t.string   "link",               limit: 255
   end
 
   create_table "hidden_stories", force: :cascade do |t|
-    t.integer "user_id",  limit: 4
-    t.integer "story_id", limit: 4
+    t.integer "user_id"
+    t.integer "story_id"
   end
 
   add_index "hidden_stories", ["user_id", "story_id"], name: "index_hidden_stories_on_user_id_and_story_id", unique: true, using: :btree
 
   create_table "invitation_requests", force: :cascade do |t|
     t.string   "code",        limit: 255
-    t.boolean  "is_verified",               default: false
+    t.boolean  "is_verified",             default: false
     t.string   "email",       limit: 255
     t.string   "name",        limit: 255
-    t.text     "memo",        limit: 65535
+    t.text     "memo"
     t.string   "ip_address",  limit: 255
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
   end
 
   create_table "invitations", force: :cascade do |t|
-    t.integer  "user_id",    limit: 4
+    t.integer  "user_id"
     t.string   "email",      limit: 255
     t.string   "code",       limit: 255
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.text     "memo",       limit: 16777215
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.text     "memo"
   end
 
   create_table "keystores", id: false, force: :cascade do |t|
@@ -92,49 +95,50 @@ ActiveRecord::Schema.define(version: 20170522144135) do
 
   create_table "messages", force: :cascade do |t|
     t.datetime "created_at"
-    t.integer  "author_user_id",       limit: 4
-    t.integer  "recipient_user_id",    limit: 4
-    t.boolean  "has_been_read",                         default: false
+    t.integer  "author_user_id"
+    t.integer  "recipient_user_id"
+    t.boolean  "has_been_read",                    default: false
     t.string   "subject",              limit: 100
-    t.text     "body",                 limit: 16777215
+    t.text     "body"
     t.string   "short_id",             limit: 30
-    t.boolean  "deleted_by_author",                     default: false
-    t.boolean  "deleted_by_recipient",                  default: false
+    t.boolean  "deleted_by_author",                default: false
+    t.boolean  "deleted_by_recipient",             default: false
   end
 
   add_index "messages", ["short_id"], name: "random_hash", unique: true, using: :btree
 
   create_table "moderations", force: :cascade do |t|
-    t.datetime "created_at",                                           null: false
-    t.datetime "updated_at",                                           null: false
-    t.integer  "moderator_user_id",   limit: 4
-    t.integer  "story_id",            limit: 4
-    t.integer  "comment_id",          limit: 4
-    t.integer  "user_id",             limit: 4
-    t.text     "action",              limit: 16777215
-    t.text     "reason",              limit: 16777215
-    t.boolean  "is_from_suggestions",                  default: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.integer  "moderator_user_id"
+    t.integer  "story_id"
+    t.integer  "comment_id"
+    t.integer  "user_id"
+    t.text     "action"
+    t.text     "reason"
+    t.boolean  "is_from_suggestions", default: false
   end
 
   create_table "stories", force: :cascade do |t|
     t.datetime "created_at"
-    t.integer  "user_id",                limit: 4
-    t.string   "url",                    limit: 250,                                default: ""
-    t.string   "title",                  limit: 150,                                default: "",    null: false
-    t.text     "description",            limit: 16777215
-    t.string   "short_id",               limit: 6,                                  default: "",    null: false
-    t.boolean  "is_expired",                                                        default: false, null: false
-    t.integer  "upvotes",                limit: 4,                                  default: 0,     null: false
-    t.integer  "downvotes",              limit: 4,                                  default: 0,     null: false
-    t.boolean  "is_moderated",                                                      default: false, null: false
-    t.decimal  "hotness",                                 precision: 20, scale: 10, default: 0.0,   null: false
-    t.text     "markeddown_description", limit: 16777215
-    t.text     "story_cache",            limit: 16777215
-    t.integer  "comments_count",         limit: 4,                                  default: 0,     null: false
-    t.integer  "merged_story_id",        limit: 4
+    t.integer  "user_id"
+    t.string   "url",                    limit: 250,                           default: ""
+    t.string   "title",                  limit: 150,                           default: "",    null: false
+    t.text     "description"
+    t.string   "short_id",               limit: 6,                             default: "",    null: false
+    t.boolean  "is_expired",                                                   default: false, null: false
+    t.integer  "upvotes",                                                      default: 0,     null: false
+    t.integer  "downvotes",                                                    default: 0,     null: false
+    t.boolean  "is_moderated",                                                 default: false, null: false
+    t.decimal  "hotness",                            precision: 20, scale: 10, default: 0.0,   null: false
+    t.text     "markeddown_description"
+    t.text     "story_cache"
+    t.integer  "comments_count",                                               default: 0,     null: false
+    t.integer  "merged_story_id"
     t.datetime "unavailable_at"
     t.string   "twitter_id",             limit: 20
-    t.boolean  "user_is_author",                                                    default: false
+    t.boolean  "user_is_author",                                               default: false
+    t.datetime "updated_at"
   end
 
   add_index "stories", ["created_at"], name: "index_stories_on_created_at", using: :btree
@@ -145,32 +149,32 @@ ActiveRecord::Schema.define(version: 20170522144135) do
   add_index "stories", ["merged_story_id"], name: "index_stories_on_merged_story_id", using: :btree
   add_index "stories", ["short_id"], name: "unique_short_id", unique: true, using: :btree
   add_index "stories", ["twitter_id"], name: "index_stories_on_twitter_id", using: :btree
-  add_index "stories", ["url"], name: "url", length: {"url"=>191}, using: :btree
+  add_index "stories", ["url"], name: "url", using: :btree
 
   create_table "suggested_taggings", force: :cascade do |t|
-    t.integer "story_id", limit: 4
-    t.integer "tag_id",   limit: 4
-    t.integer "user_id",  limit: 4
+    t.integer "story_id"
+    t.integer "tag_id"
+    t.integer "user_id"
   end
 
   create_table "suggested_titles", force: :cascade do |t|
-    t.integer "story_id", limit: 4
-    t.integer "user_id",  limit: 4
+    t.integer "story_id"
+    t.integer "user_id"
     t.string  "title",    limit: 150, default: "", null: false
   end
 
   create_table "tag_filters", force: :cascade do |t|
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
-    t.integer  "user_id",    limit: 4
-    t.integer  "tag_id",     limit: 4
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer  "user_id"
+    t.integer  "tag_id"
   end
 
   add_index "tag_filters", ["user_id", "tag_id"], name: "user_tag_idx", using: :btree
 
   create_table "taggings", force: :cascade do |t|
-    t.integer "story_id", limit: 4, null: false
-    t.integer "tag_id",   limit: 4, null: false
+    t.integer "story_id", null: false
+    t.integer "tag_id",   null: false
   end
 
   add_index "taggings", ["story_id", "tag_id"], name: "story_id_tag_id", unique: true, using: :btree
@@ -181,7 +185,7 @@ ActiveRecord::Schema.define(version: 20170522144135) do
     t.boolean "privileged",              default: false
     t.boolean "is_media",                default: false
     t.boolean "inactive",                default: false
-    t.float   "hotness_mod", limit: 24,  default: 0.0
+    t.float   "hotness_mod",             default: 0.0
   end
 
   add_index "tags", ["tag"], name: "tag", unique: true, using: :btree
@@ -191,25 +195,25 @@ ActiveRecord::Schema.define(version: 20170522144135) do
     t.string   "email",                      limit: 100
     t.string   "password_digest",            limit: 75
     t.datetime "created_at"
-    t.boolean  "is_admin",                                    default: false
+    t.boolean  "is_admin",                               default: false
     t.string   "password_reset_token",       limit: 75
-    t.string   "session_token",              limit: 75,       default: "",    null: false
-    t.text     "about",                      limit: 16777215
-    t.integer  "invited_by_user_id",         limit: 4
-    t.boolean  "is_moderator",                                default: false
-    t.boolean  "pushover_mentions",                           default: false
+    t.string   "session_token",              limit: 75,  default: "",    null: false
+    t.text     "about"
+    t.integer  "invited_by_user_id"
+    t.boolean  "is_moderator",                           default: false
+    t.boolean  "pushover_mentions",                      default: false
     t.string   "rss_token",                  limit: 75
     t.string   "mailing_list_token",         limit: 75
-    t.integer  "mailing_list_mode",          limit: 4,        default: 0
-    t.integer  "karma",                      limit: 4,        default: 0,     null: false
+    t.integer  "mailing_list_mode",                      default: 0
+    t.integer  "karma",                                  default: 0,     null: false
     t.datetime "banned_at"
-    t.integer  "banned_by_user_id",          limit: 4
+    t.integer  "banned_by_user_id"
     t.string   "banned_reason",              limit: 200
     t.datetime "deleted_at"
     t.datetime "disabled_invite_at"
-    t.integer  "disabled_invite_by_user_id", limit: 4
+    t.integer  "disabled_invite_by_user_id"
     t.string   "disabled_invite_reason",     limit: 200
-    t.text     "settings",                   limit: 65535
+    t.text     "settings"
   end
 
   add_index "users", ["mailing_list_mode"], name: "mailing_list_enabled", using: :btree
@@ -220,10 +224,10 @@ ActiveRecord::Schema.define(version: 20170522144135) do
   add_index "users", ["username"], name: "username", unique: true, using: :btree
 
   create_table "votes", force: :cascade do |t|
-    t.integer "user_id",    limit: 4, null: false
-    t.integer "story_id",   limit: 4, null: false
-    t.integer "comment_id", limit: 4
-    t.integer "vote",       limit: 1, null: false
+    t.integer "user_id",              null: false
+    t.integer "story_id",             null: false
+    t.integer "comment_id"
+    t.integer "vote",       limit: 2, null: false
     t.string  "reason",     limit: 1
   end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe CommentsController do
+  describe "create" do
+    let!(:user) { User.make! }
+    let!(:story){ Story.make!(:created_at => 2.days.ago, :updated_at => 2.days.ago) }
+    it "updates the updated_at for the parent story" do
+      request.session[:u] = user.session_token
+      expect {
+        post :create,
+            :story_id => story.short_id, :comment => "Hello"
+      }.to change{ story.reload.updated_at }
+
+      response.should be_success
+    end
+  end
+end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -3,13 +3,13 @@ require "spec_helper"
 describe Story do
 
   describe "self.ready_for_deletion" do
-    it "includes stories older than 1 month" do
-      s = Story.make!(:created_at => 5.months.ago)
+    it "includes stories updated last updated more than 1 month" do
+      s = Story.make!(:updated_at => 5.months.ago)
       expect( Story.ready_for_deletion).to include(s)
     end
 
-    it "does not include stories less than 1 month old" do
-      s = Story.make!(:created_at => 3.weeks.ago)
+    it "does not include stories last updated less than 1 month ago" do
+      s = Story.make!(:updated_at => 3.weeks.ago)
 
       expect(Story.ready_for_deletion).to_not include(s)
     end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -15,6 +15,15 @@ describe Story do
     end
   end
 
+  describe "time_until_deletion" do
+    it "calculates time until deletion" do
+      now = Time.now
+      s = Story.make!(:updated_at => now - 2.weeks)
+
+      expect(s.time_until_deletion(now)).to be_within(0.1).of(2.weeks.to_f)
+    end
+  end
+
   describe "destroy" do
     it "preserves users karma" do
       submitter = User.make!


### PR DESCRIPTION
This changes the deletion logic to rely on a story's updated_at. A story is updated when a comment is added, allowing active stories to remain. This also displays time until deletion on the story view, using CSS to adjust color to show urgency.

If someone wants to do some more color picker fiddling, I'd appreciate it.